### PR TITLE
OMS7-N: Allow Play Store to filter out OMS-only themes

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,6 +13,7 @@ LOCAL_MODULE_TAGS := optional
 
 LOCAL_MANIFEST_FILE := app/src/main/AndroidManifest.xml
 LOCAL_SRC_FILES := $(call all-java-files-under, app/src/main)
+LOCAL_REQUIRED_MODULES := projekt.substratum.theme.xml
 LOCAL_RESOURCE_DIR := $(LOCAL_PATH)/app/src/main/res
 
 LOCAL_AAPT_FLAGS := --auto-add-overlay
@@ -21,3 +22,11 @@ LOCAL_AAPT_INCLUDE_ALL_RESOURCES := true
 include $(BUILD_PACKAGE)
 
 include $(CLEAR_VARS)
+
+LOCAL_MODULE := projekt.substratum.theme.xml
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/permissions
+LOCAL_SRC_FILES := $(LOCAL_MODULE)
+
+include $(BUILD_PREBUILT)

--- a/projekt.substratum.theme.xml
+++ b/projekt.substratum.theme.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 Project Substratum
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<permissions>
+    <!-- Limitation permission to block out themes from being visible on stock
+         AOSP, or non-OMS devices. -->
+
+    <!-- This is an alias for projekt.substratum.theme -->
+    <feature name="projekt.substratum.theme" />
+
+</permissions>


### PR DESCRIPTION
This will be used in the separation of OMS and Legacy themes, and gets
added inside /system/etc/permissions.

Themers: To utilize this to create a theme only viewable on an OMS ROM,
add:

    <uses-feature
        android:name="projekt.substratum.theme"
        android:required="true" />

to the AndroidManifest.xml in the theme's APK. Play Store will limit the
theme to be viewed on OMS-only devices.

Change-Id: Ibcda2fb3ecd4004d2a3c12560b4e7bdc07505703